### PR TITLE
fix: user can not log in if their membership is expired

### DIFF
--- a/backend/controllers/auth.ts
+++ b/backend/controllers/auth.ts
@@ -12,6 +12,19 @@ export async function login(req: Request, res: Response) {
     );
     const userProfile = await getNtnuiProfile(tokens.access);
 
+    // User must have a valid NTNUI membership for logging into the application.
+    // The membership are valid until and including the expiry date.
+    if (
+      !userProfile.data.contract_expiry_date ||
+      new Date(userProfile.data.contract_expiry_date || "") <
+        new Date(new Date().toISOString().split("T")[0])
+    ) {
+      return res.status(403).send({
+        message: "Unauthorized",
+        info: "NTNUI membership is expired",
+      });
+    }
+
     let mainAssemblyOrganizer = false;
 
     // Members of the Main Board can modify the main assembly

--- a/frontend/src/components/LoginForm.tsx
+++ b/frontend/src/components/LoginForm.tsx
@@ -117,7 +117,9 @@ export function LoginForm() {
   const { classes } = useStyles();
   let navigate = useNavigate();
   const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState(false);
+  const [error, setError] = useState<{ active: Boolean; errorCode?: number }>({
+    active: false,
+  });
 
   useEffect(() => {
     // Log user in and redirect if user is already logged in.
@@ -171,9 +173,9 @@ export function LoginForm() {
           navigate("/start");
           localStorage.setItem("isLoggedIn", "true");
         })
-        .catch(() => {
+        .catch((error) => {
           setIsLoading(false);
-          setError(true);
+          setError({ active: true, errorCode: error.response.status });
           localStorage.setItem("isLoggedIn", "false");
         });
     } catch (error) {
@@ -274,7 +276,9 @@ export function LoginForm() {
           color="red"
           data-testid="bad-login-notification"
         >
-          Cannot find any user with this password and username
+          {error.errorCode === 403
+            ? "No active NTNUI membership found on the given user"
+            : "Cannot find any user with this password and username"}
         </Notification>
       )}
       <Button


### PR DESCRIPTION
Now a user cannot log in if their NTNUI membership is expired.
Wrong credentials:

<img width="541" alt="Skjermbilde 2023-04-26 kl  15 07 02" src="https://user-images.githubusercontent.com/41023500/234584297-fa030d38-d965-4317-bf62-a6f94898f453.png">

Correct credentials, but no active membership:
<img width="541" alt="Skjermbilde 2023-04-26 kl  15 07 55" src="https://user-images.githubusercontent.com/41023500/234584517-aeb35f48-f30c-4d3a-be3a-49eff8b5bbcd.png">

