### PR TITLE
feat: use ws with route support instead of express-ws

### DIFF
--- a/.github/workflows/deploy-dev-vote-frontend.yml
+++ b/.github/workflows/deploy-dev-vote-frontend.yml
@@ -37,7 +37,7 @@ jobs:
           ###### End of Repository/Build Configurations ######
         env:
           VITE_BACKEND_URL: https://api.dev.vote.ntnui.no
-          VITE_SOCKET_URL: wss://api.dev.vote.ntnui.no/status
+          VITE_SOCKET_URL: wss://api.dev.vote.ntnui.no/lobby
 
   close_pull_request_job:
     if: github.event_name == 'pull_request' && github.event.action == 'closed'

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 **/.DS_Store
 **/node_modules
 **/.env
+**/.vscode

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -14,10 +14,10 @@
         "cors": "^2.8.5",
         "dotenv": "^16.0.3",
         "express": "^4.18.2",
-        "express-ws": "^5.0.2",
         "jsonwebtoken": "^9.0.0",
         "mongoose": "^6.9.0",
-        "ntnui-tools": "github:NTNUI/ntnui-tools"
+        "ntnui-tools": "github:NTNUI/ntnui-tools",
+        "ws": "^8.13.0"
       },
       "devDependencies": {
         "@types/cookie-parser": "^1.4.3",
@@ -3395,20 +3395,6 @@
         "node": ">= 0.10.0"
       }
     },
-    "node_modules/express-ws": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/express-ws/-/express-ws-5.0.2.tgz",
-      "integrity": "sha512-0uvmuk61O9HXgLhGl3QhNSEtRsQevtmbL94/eILaliEADZBHZOQUAiHFrGPrgsjikohyrmSG5g+sCfASTt0lkQ==",
-      "dependencies": {
-        "ws": "^7.4.6"
-      },
-      "engines": {
-        "node": ">=4.5.0"
-      },
-      "peerDependencies": {
-        "express": "^4.0.0 || ^5.0.0-alpha.1"
-      }
-    },
     "node_modules/express/node_modules/cookie": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
@@ -6407,15 +6393,15 @@
       }
     },
     "node_modules/ws": {
-      "version": "7.5.9",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
       "engines": {
-        "node": ">=8.3.0"
+        "node": ">=10.0.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
+        "utf-8-validate": ">=5.0.2"
       },
       "peerDependenciesMeta": {
         "bufferutil": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -44,7 +44,7 @@
     "cors": "^2.8.5",
     "dotenv": "^16.0.3",
     "express": "^4.18.2",
-    "express-ws": "^5.0.2",
+    "ws": "^8.13.0",
     "jsonwebtoken": "^9.0.0",
     "mongoose": "^6.9.0",
     "ntnui-tools": "github:NTNUI/ntnui-tools"

--- a/backend/utils/socketNotifier.ts
+++ b/backend/utils/socketNotifier.ts
@@ -1,4 +1,4 @@
-import { connections } from "..";
+import { connections } from "./wsCookieRetriever";
 
 export const notifyOne = (ntnui_no: number, message: string) => {
   try {

--- a/backend/utils/wsCookieRetriever.ts
+++ b/backend/utils/wsCookieRetriever.ts
@@ -1,0 +1,34 @@
+import jsonwebtoken from "jsonwebtoken";
+import { notifyOne } from "../utils/socketNotifier";
+import { IncomingMessage } from "http";
+import { WebSocket } from "ws";
+
+// Store all active connections, for access when sending messages.
+export const connections: WebSocket[] = [];
+
+export function storeConnectionByCookie(ws: WebSocket, req: IncomingMessage) {
+  // WS do not support direct access to cookies, so we have to parse them manually into a map for easy access.
+  const cookies = req.headers.cookie ? req.headers.cookie.split("; ") : [];
+
+  const cookieMap: CookieMap = {};
+  cookies.forEach((cookie) => {
+    const [name, value] = cookie.split("=");
+    cookieMap[name] = value;
+  });
+
+  if (cookieMap["accessToken"] !== undefined) {
+    const decoded = jsonwebtoken.decode(cookieMap["accessToken"]);
+    if (decoded && typeof decoded !== "string") {
+      // Notify about kicking out old connection if user already is connected.
+      if (typeof connections[decoded.ntnui_no] !== "undefined") {
+        notifyOne(decoded.ntnui_no, JSON.stringify({ status: "removed" }));
+      }
+      // Store socket connection on NTNUI ID.
+      connections[decoded.ntnui_no] = ws;
+    }
+  }
+}
+
+interface CookieMap {
+  [key: string]: string;
+}

--- a/backend/wsServers/lobby.ts
+++ b/backend/wsServers/lobby.ts
@@ -1,0 +1,9 @@
+import { WebSocketServer } from "ws";
+import { storeConnectionByCookie } from "../utils/wsCookieRetriever";
+
+export const lobbyWss = new WebSocketServer({ noServer: true });
+
+lobbyWss.on("connection", function connection(ws, req) {
+  // Store connections to be able to send messages to specific users when needed.
+  storeConnectionByCookie(ws, req);
+});

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -16,7 +16,7 @@ Contents for developing locally:
 
 ```
 VITE_BACKEND_URL=http://localhost:3000/
-VITE_SOCKET_URL=ws://localhost:3000/status
+VITE_SOCKET_URL=ws://localhost:3000/lobby
 ```
 
 ### Then install dependencies and start the app


### PR DESCRIPTION
Closes #182

Removes not so maintained [express-ws](https://www.npmjs.com/package/express-ws) in favor of using [ws](https://www.npmjs.com/package/ws) directly.
I also added support for multiple WebSocket-servers by adding a router for ws-requests.