### PR TITLE
fix: synchronize live vote count when multiple organizers are logged in

### DIFF
--- a/backend/controllers/votation.ts
+++ b/backend/controllers/votation.ts
@@ -417,6 +417,8 @@ export async function deactivateVotationStatus(
         );
       });
 
+      notifyOrganizers(group, JSON.stringify({ voteEnded: true }));
+
       return res
         .status(200)
         .json({ message: "Votation successfully deactivated" });

--- a/frontend/src/components/EditAssembly.tsx
+++ b/frontend/src/components/EditAssembly.tsx
@@ -60,6 +60,9 @@ export function EditAssembly(state: { group: UserDataGroupType }) {
           submittedVotes + parseInt(decodedMessage.voteSubmitted)
         );
       }
+      if (decodedMessage.voteEnded) {
+        setSubmittedVotes(0);
+      }
     }
   }, [lastMessage]);
 


### PR DESCRIPTION
Resets vote count for all organizers logged in when a vote has ended


https://github.com/NTNUI/vote2/assets/41023500/6948e0d7-fb62-4064-9809-ca2490c1d344

