### PR TITLE
feat: log the group a user represents when checking in to main assembly

### DIFF
--- a/backend/controllers/qr.ts
+++ b/backend/controllers/qr.ts
@@ -141,7 +141,7 @@ export async function assemblyCheckin(req: RequestWithNtnuiNo, res: Response) {
     } catch (e) {
       return res
         .status(401)
-        .json({ message: "Something went wrong (Invalid credentials?) " + e });
+        .json({ message: "Something went wrong (Invalid credentials?)" });
     }
   }
   return res.status(401).json({ message: "Unauthorized" });

--- a/backend/models/log.ts
+++ b/backend/models/log.ts
@@ -8,13 +8,17 @@ const logSchema = new Schema<logType>(
       type: String,
       required: true,
     },
+    representsGroup: {
+      type: String,
+      required: true,
+    },
     action: {
       type: String,
       enum: logActionTypes,
       required: true,
     },
     user: {
-      type: userSchema,
+      type: Number,
       required: true,
     },
   },

--- a/backend/types/log.ts
+++ b/backend/types/log.ts
@@ -7,6 +7,7 @@ export enum logActionTypes {
 
 export interface logType {
   assemblyID: string;
+  representsGroup: string;
   action: logActionTypes;
   user: UserType;
 }

--- a/frontend/src/components/QrCode.tsx
+++ b/frontend/src/components/QrCode.tsx
@@ -5,7 +5,7 @@ import { getQrData } from "../services/qr";
 import logo from "../assets/ntnuiColor.svg";
 import { useParams } from "react-router-dom";
 
-export function QrCode() {
+export function QrCode({ representsGroup }: { representsGroup?: string }) {
   const { groupSlug } = useParams() as { groupSlug: string };
   const [QRData, setQRData] = useState<string>();
   const updateQR = async () => {
@@ -33,6 +33,7 @@ export function QrCode() {
       value={JSON.stringify({
         QRData: QRData,
         group: groupSlug,
+        representsGroup: representsGroup,
       })}
     />
   );

--- a/frontend/src/pages/CheckIn.tsx
+++ b/frontend/src/pages/CheckIn.tsx
@@ -24,8 +24,8 @@ export function CheckIn() {
     if (result) {
       try {
         const decodedResult = JSON.parse(result);
-        const { QRData, group } = decodedResult;
-        checkInUser({ QRData, group });
+        const { QRData, group, representsGroup } = decodedResult;
+        checkInUser({ QRData, group, representsGroup });
       } catch (error) {
         showNotification({
           title: "Error",

--- a/frontend/src/services/qr.ts
+++ b/frontend/src/services/qr.ts
@@ -12,6 +12,7 @@ export const assemblyCheckin = async (
     const res = await axios.post("/qr/checkin", {
       QRData: qrScan.QRData,
       group: qrScan.group,
+      representsGroup: qrScan.representsGroup,
     });
     if (res.status == 200) {
       return {

--- a/frontend/src/types/checkin.ts
+++ b/frontend/src/types/checkin.ts
@@ -1,4 +1,5 @@
 export type QRType = {
   QRData: string;
   group: string;
+  representsGroup: string;
 };


### PR DESCRIPTION
**Draft - I appreciate suggestions 🤓**

It is required for all groups to attend the main assembly.
Therefore when a user attends the main assembly they have to choose which group they represent.
This is only logged when a user is checking in to the assembly (the frontend will not store the group the user represents), but when they leave we can assume they represent the same group as when they arrived (not possible to change without checking in and out anyways).

Logging is now also restricted to the main assembly, as logging other assemblies is not necessary.