### PR TITLE
feat: add heartbeat to WS for persistent connections

### DIFF
--- a/backend/controllers/assembly.ts
+++ b/backend/controllers/assembly.ts
@@ -4,6 +4,7 @@ import { User } from "../models/user";
 import { Votation, Option } from "../models/vote";
 import { RequestWithNtnuiNo } from "../utils/request";
 import { AssemblyResponseType } from "../types/assembly";
+import { organizerConnections } from "../utils/socketNotifier";
 
 export async function createAssembly(req: RequestWithNtnuiNo, res: Response) {
   if (!req.ntnuiNo) {
@@ -109,7 +110,10 @@ export async function deleteAssembly(req: RequestWithNtnuiNo, res: Response) {
         }
         await Votation.findByIdAndDelete(vote);
       });
+
       await Assembly.deleteOne({ _id: assembly._id });
+      // Clean up websocket connections for this assembly
+      organizerConnections.delete(group);
       return res.status(200).json({ message: "Assembly successfully deleted" });
     }
   }

--- a/backend/index.ts
+++ b/backend/index.ts
@@ -65,7 +65,10 @@ server.on("upgrade", function upgrade(request, socket, head) {
 });
 
 // Start sending pings/Heartbeat to ws-connections to keep connections alive.
-startHeartbeatInterval;
+// Not started when testing, as Jest will not stop properly if the interval is running.
+if (process.env.NODE_ENV !== "test") {
+  startHeartbeatInterval;
+}
 
 try {
   // Jest will start app itself when testing, and not run on port 3000 to avoid collisions.

--- a/backend/index.ts
+++ b/backend/index.ts
@@ -13,6 +13,7 @@ import votationRoutes from "./routes/votation";
 import { parse } from "url";
 import { lobbyWss } from "./wsServers/lobby";
 import { organizerWss } from "./wsServers/organizer";
+import { startHeartbeatInterval } from "./utils/socketNotifier";
 
 dotenv.config();
 
@@ -62,6 +63,9 @@ server.on("upgrade", function upgrade(request, socket, head) {
     socket.destroy();
   }
 });
+
+// Start sending pings/Heartbeat to ws-connections to keep connections alive.
+startHeartbeatInterval;
 
 try {
   // Jest will start app itself when testing, and not run on port 3000 to avoid collisions.

--- a/backend/wsServers/lobby.ts
+++ b/backend/wsServers/lobby.ts
@@ -1,9 +1,20 @@
 import { WebSocketServer } from "ws";
-import { storeLobbyConnectionByCookie } from "../utils/socketNotifier";
+import {
+  removeLobbyConnectionByCookie,
+  storeLobbyConnectionByCookie,
+} from "../utils/socketNotifier";
 
 export const lobbyWss = new WebSocketServer({ noServer: true });
 
 lobbyWss.on("connection", function connection(ws, req) {
   // Store connections to be able to send messages to specific users when needed.
   storeLobbyConnectionByCookie(ws, req);
+
+  ws.on("pong", () => {
+    // The client responded to the ping, so the connection is still active.
+  });
+
+  ws.on("close", () => {
+    removeLobbyConnectionByCookie(req);
+  });
 });

--- a/backend/wsServers/lobby.ts
+++ b/backend/wsServers/lobby.ts
@@ -1,8 +1,5 @@
 import { WebSocketServer } from "ws";
-import {
-  storeLobbyConnectionByCookie,
-  waitingForPongLobby,
-} from "../utils/socketNotifier";
+import { storeLobbyConnectionByCookie } from "../utils/socketNotifier";
 import { NTNUINoFromRequest } from "../utils/wsCookieRetriever";
 
 export const lobbyWss = new WebSocketServer({ noServer: true });
@@ -13,6 +10,6 @@ lobbyWss.on("connection", function connection(ws, req) {
 
   ws.on("pong", () => {
     // The client responded to the ping, so the connection is still active.
-    waitingForPongLobby.set(NTNUINoFromRequest(req) || 0, false);
+    // Connections are deleted when the user logs out or closes the connection/tab.
   });
 });

--- a/backend/wsServers/lobby.ts
+++ b/backend/wsServers/lobby.ts
@@ -1,6 +1,5 @@
 import { WebSocketServer } from "ws";
 import { storeLobbyConnectionByCookie } from "../utils/socketNotifier";
-import { NTNUINoFromRequest } from "../utils/wsCookieRetriever";
 
 export const lobbyWss = new WebSocketServer({ noServer: true });
 

--- a/backend/wsServers/lobby.ts
+++ b/backend/wsServers/lobby.ts
@@ -1,8 +1,9 @@
 import { WebSocketServer } from "ws";
 import {
-  removeLobbyConnectionByCookie,
   storeLobbyConnectionByCookie,
+  waitingForPongLobby,
 } from "../utils/socketNotifier";
+import { NTNUINoFromRequest } from "../utils/wsCookieRetriever";
 
 export const lobbyWss = new WebSocketServer({ noServer: true });
 
@@ -12,9 +13,6 @@ lobbyWss.on("connection", function connection(ws, req) {
 
   ws.on("pong", () => {
     // The client responded to the ping, so the connection is still active.
-  });
-
-  ws.on("close", () => {
-    removeLobbyConnectionByCookie(req);
+    waitingForPongLobby.set(NTNUINoFromRequest(req) || 0, false);
   });
 });

--- a/backend/wsServers/organizer.ts
+++ b/backend/wsServers/organizer.ts
@@ -52,8 +52,4 @@ organizerWss.on("connection", function connection(ws, req) {
   ws.on("pong", () => {
     // The client responded to the ping, so the connection is still active.
   });
-
-  ws.on("close", () => {
-    removeOrganizerConnectionByCookie(req);
-  });
 });

--- a/backend/wsServers/organizer.ts
+++ b/backend/wsServers/organizer.ts
@@ -1,10 +1,7 @@
 import { WebSocketServer } from "ws";
 import { NTNUINoFromRequest } from "../utils/wsCookieRetriever";
 import { User } from "../models/user";
-import {
-  removeOrganizerConnectionByCookie,
-  storeOrganizerConnectionByNTNUINo,
-} from "../utils/socketNotifier";
+import { storeOrganizerConnection } from "../utils/socketNotifier";
 
 export const organizerWss = new WebSocketServer({ noServer: true });
 
@@ -31,7 +28,7 @@ organizerWss.on("connection", function connection(ws, req) {
               membership.organizer && membership.groupSlug == groupSlug
           )
         ) {
-          storeOrganizerConnectionByNTNUINo(ntnuiNo, groupSlug, ws);
+          storeOrganizerConnection(groupSlug, ws);
           console.log(
             "Organizer " + ntnuiNo + " are subscribed to group " + groupSlug
           );
@@ -51,5 +48,6 @@ organizerWss.on("connection", function connection(ws, req) {
 
   ws.on("pong", () => {
     // The client responded to the ping, so the connection is still active.
+    // Connections are deleted when the assembly is deleted or the organizer closes the connection/tab.
   });
 });

--- a/backend/wsServers/organizer.ts
+++ b/backend/wsServers/organizer.ts
@@ -1,7 +1,10 @@
 import { WebSocketServer } from "ws";
 import { NTNUINoFromRequest } from "../utils/wsCookieRetriever";
 import { User } from "../models/user";
-import { storeOrganizerConnectionByNTNUINo } from "../utils/socketNotifier";
+import {
+  removeOrganizerConnectionByCookie,
+  storeOrganizerConnectionByNTNUINo,
+} from "../utils/socketNotifier";
 
 export const organizerWss = new WebSocketServer({ noServer: true });
 
@@ -44,5 +47,13 @@ organizerWss.on("connection", function connection(ws, req) {
       // User not logged in / invalid cookie
       ws.close();
     }
+  });
+
+  ws.on("pong", () => {
+    // The client responded to the ping, so the connection is still active.
+  });
+
+  ws.on("close", () => {
+    removeOrganizerConnectionByCookie(req);
   });
 });

--- a/frontend/src/components/EditAssembly.tsx
+++ b/frontend/src/components/EditAssembly.tsx
@@ -40,7 +40,14 @@ export function EditAssembly(state: { group: UserDataGroupType }) {
   const [accordionActiveTabs, setAccordionActiveTabs] = useState<string[]>([]);
 
   const { lastMessage, sendJsonMessage } = useWebSocket(
-    import.meta.env.VITE_SOCKET_URL + "/organizer"
+    import.meta.env.VITE_SOCKET_URL + "/organizer",
+    {
+      //Will attempt to reconnect on all close events, such as server shutting down
+      shouldReconnect: () => true,
+      // Try to reconnect 300 times before giving up.
+      // Also possible to change interval (default is 5000ms)
+      reconnectAttempts: 300,
+    }
   );
 
   // Request access to live assembly data for the given group when component is mounted.

--- a/frontend/src/components/EditAssembly.tsx
+++ b/frontend/src/components/EditAssembly.tsx
@@ -42,6 +42,8 @@ export function EditAssembly(state: { group: UserDataGroupType }) {
   const { lastMessage, sendJsonMessage } = useWebSocket(
     import.meta.env.VITE_SOCKET_URL + "/organizer",
     {
+      // Request access to live assembly data for the given group when the websocket is opened.
+      onOpen: () => sendJsonMessage({ groupSlug: group.groupSlug }),
       //Will attempt to reconnect on all close events, such as server shutting down
       shouldReconnect: () => true,
       // Try to reconnect 300 times before giving up.
@@ -49,11 +51,6 @@ export function EditAssembly(state: { group: UserDataGroupType }) {
       reconnectAttempts: 300,
     }
   );
-
-  // Request access to live assembly data for the given group when component is mounted.
-  useEffect(() => {
-    sendJsonMessage({ groupSlug: group.groupSlug });
-  }, []);
 
   useEffect(() => {
     // Update state every time the websocket receive a message.

--- a/frontend/src/pages/AssemblyPage.tsx
+++ b/frontend/src/pages/AssemblyPage.tsx
@@ -13,7 +13,7 @@ import { LimitedVoteType } from "../types/votes";
 import { getUserData } from "../services/organizer";
 import { NotFound } from "./NotFound";
 
-export function AssemblyLobby() {
+export function AssemblyLobxby() {
   let navigate = useNavigate();
   const { groupSlug } = useParams() as { groupSlug: string };
   const [groupName, setGroupName] = useState<string | undefined>(undefined);
@@ -26,7 +26,14 @@ export function AssemblyLobby() {
   >(undefined);
   const [voted, setVoted] = useState<boolean>(false);
   const { lastMessage } = useWebSocket(
-    import.meta.env.VITE_SOCKET_URL + "/lobby"
+    import.meta.env.VITE_SOCKET_URL + "/lobby",
+    {
+      //Will attempt to reconnect on all close events, such as server shutting down
+      shouldReconnect: () => true,
+      // Try to reconnect 300 times before giving up.
+      // Also possible to change interval (default is 5000ms)
+      reconnectAttempts: 300,
+    }
   );
   const { checkedIn, setCheckedIn } = useContext(
     checkedInState

--- a/frontend/src/pages/AssemblyPage.tsx
+++ b/frontend/src/pages/AssemblyPage.tsx
@@ -13,7 +13,7 @@ import { LimitedVoteType } from "../types/votes";
 import { getUserData } from "../services/organizer";
 import { NotFound } from "./NotFound";
 
-export function AssemblyLobxby() {
+export function AssemblyLobby() {
   let navigate = useNavigate();
   const { groupSlug } = useParams() as { groupSlug: string };
   const [groupName, setGroupName] = useState<string | undefined>(undefined);
@@ -25,11 +25,11 @@ export function AssemblyLobxby() {
     LimitedVoteType | undefined
   >(undefined);
   const [voted, setVoted] = useState<boolean>(false);
-  const { lastMessage } = useWebSocket(
+  const { lastMessage, getWebSocket } = useWebSocket(
     import.meta.env.VITE_SOCKET_URL + "/lobby",
     {
       //Will attempt to reconnect on all close events, such as server shutting down
-      shouldReconnect: () => true,
+      shouldReconnect: () => !kickedOut,
       // Try to reconnect 300 times before giving up.
       // Also possible to change interval (default is 5000ms)
       reconnectAttempts: 300,
@@ -79,6 +79,7 @@ export function AssemblyLobxby() {
       // User is is removed from current lobby if logged in on another device.
       if (decodedMessage.status == "removed") {
         setKickedOut(true);
+        getWebSocket()?.close();
       }
       // Redirect only if user is checked in on the right group.
       if (decodedMessage.group == groupSlug) {

--- a/frontend/src/pages/AssemblyPage.tsx
+++ b/frontend/src/pages/AssemblyPage.tsx
@@ -141,7 +141,7 @@ export function AssemblyLobby() {
       {kickedOut ? (
         <WaitingRoom
           message={
-            "You have logged in on another device, or you are kicked from this assembly."
+            "You have logged in on another device/tab, this tab is therefore disconnected."
           }
         />
       ) : checkedIn && groupSlug && voted ? (


### PR DESCRIPTION
Added heartbeat to both lobby and organizer webSocket endpoints for making connections persist. Also cleaning up and remove connections if they are closed.
Now an organizer also can get ws events at the same time on multiple tabs/devices on the organizer view.