### PR TITLE
fix: create interceptor for refreshing access token

### DIFF
--- a/backend/controllers/auth.ts
+++ b/backend/controllers/auth.ts
@@ -3,7 +3,6 @@ import { getNtnuiToken, getNtnuiProfile, refreshNtnuiToken } from "ntnui-tools";
 import { User } from "../models/user";
 import { GroupType } from "../types/user";
 import { groupOrganizers } from "../utils/user";
-import path from "path";
 
 export async function login(req: Request, res: Response) {
   try {
@@ -103,10 +102,9 @@ export const refreshAccessToken = async (req: Request, res: Response) => {
   }
 
   try {
-    const newAccessTokenResponse = await refreshNtnuiToken(refreshToken);
-    let newAccessToken = newAccessTokenResponse.access;
+    const refreshedTokens = await refreshNtnuiToken(refreshToken);
     return res
-      .cookie("accessToken", newAccessToken, {
+      .cookie("accessToken", refreshedTokens.access, {
         maxAge: 1800000, // 30 minutes
         httpOnly: true,
         secure: process.env.NODE_ENV === "production",

--- a/backend/routes/auth.ts
+++ b/backend/routes/auth.ts
@@ -1,5 +1,5 @@
 import { Router } from "express";
-import { login, logout } from "../controllers/auth";
+import { login, logout, refreshAccessToken } from "../controllers/auth";
 
 const authRoutes = Router();
 
@@ -8,5 +8,7 @@ const authRoutes = Router();
 authRoutes.post("/login", login);
 
 authRoutes.get("/logout", logout);
+
+authRoutes.get("/token/refresh", refreshAccessToken);
 
 export default authRoutes;

--- a/backend/utils/authorizationMiddleware.ts
+++ b/backend/utils/authorizationMiddleware.ts
@@ -1,7 +1,7 @@
 import { Response, NextFunction } from "express";
 import jsonwebtoken from "jsonwebtoken";
 import { isValidNtnuiToken } from "ntnui-tools";
-import { CustomError, UnauthorizedUserError } from "ntnui-tools/customError";
+import { CustomError } from "ntnui-tools/customError";
 import { RequestWithNtnuiNo } from "./request";
 
 /**
@@ -18,7 +18,7 @@ const authorization = async (
   res: Response,
   next: NextFunction
 ) => {
-  let { accessToken } = req.cookies;
+  const { accessToken } = req.cookies;
   try {
     if (!accessToken) {
       throw new CustomError("No access token sent", 401);
@@ -32,9 +32,9 @@ const authorization = async (
       req.ntnuiNo = decoded.ntnui_no;
       return next();
     }
-    throw UnauthorizedUserError;
+    return res.status(401).json({ message: "Unauthorized" });
   } catch (error) {
-    return next(error);
+    return res.status(401).json({ message: "Unauthorized" });
   }
 };
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,7 +6,7 @@ import { AssemblyLobby } from "./pages/AssemblyPage";
 import { Assembly } from "./pages/AssemblyDashboard";
 import { CheckIn } from "./pages/CheckIn";
 import { AdminDashboard } from "./pages/AdminDashboard";
-import { MantineProvider, Text } from "@mantine/core";
+import { MantineProvider } from "@mantine/core";
 import colors from "./utils/theme";
 import { Login } from "./pages/LoginPage";
 import axios from "axios";
@@ -16,10 +16,13 @@ import { useState } from "react";
 import { NotFound } from "./pages/NotFound";
 import { checkedInState } from "./utils/Context";
 import { FAQ } from "./pages/FAQ";
+import { setupInterceptors } from "./services/axiosIntercept";
+
+axios.defaults.baseURL = import.meta.env.VITE_BACKEND_URL;
+axios.defaults.withCredentials = true;
 
 function App() {
-  axios.defaults.baseURL = import.meta.env.VITE_BACKEND_URL;
-  axios.defaults.withCredentials = true;
+  setupInterceptors();
   const [checkedIn, setCheckedIn] = useState(false);
   const [groupSlug, setGroupSlug] = useState("");
   const [groupName, setGroupName] = useState("");

--- a/frontend/src/components/Groups.tsx
+++ b/frontend/src/components/Groups.tsx
@@ -15,19 +15,6 @@ export function Groups() {
     undefined
   );
   const fetchData = async () => {
-    try {
-      const userData = await getUserData();
-      userData.groups.sort((group) => {
-        if (group.hasActiveAssembly) {
-          return -1;
-        } else {
-          return 1;
-        }
-      });
-      setUserData(userData);
-    } catch (error) {
-      navigate("/login");
-    }
     const userData = await getUserData();
     userData.groups.sort((group) => {
       if (group.hasActiveAssembly) {

--- a/frontend/src/components/LoginForm.tsx
+++ b/frontend/src/components/LoginForm.tsx
@@ -10,11 +10,10 @@ import {
 import { useForm } from "@mantine/form";
 import { useNavigate } from "react-router-dom";
 import { useEffect, useState } from "react";
-import { login } from "../services/auth";
+import { login, refreshAccessToken } from "../services/auth";
 import countryCodes from "../utils/countryCodes";
 import NtnuiInfoTooltip from "./Tooltip";
 import { ChevronDown, Lock, Phone, World, X } from "tabler-icons-react";
-import { getUserData } from "../services/organizer";
 
 const useStyles = createStyles((theme) => ({
   phoneNumberWrapper: {
@@ -124,13 +123,10 @@ export function LoginForm() {
   useEffect(() => {
     // Log user in and redirect if user is already logged in.
     const checkLogin = async () => {
-      try {
-        const userdata = await getUserData();
-        console.log(userdata);
+      const isLoggedIn = await refreshAccessToken();
+      if (isLoggedIn.status === 200) {
         navigate("/start");
         localStorage.setItem("isLoggedIn", "true");
-      } catch (e) {
-        // User is not logged in
       }
     };
     checkLogin();

--- a/frontend/src/services/auth.ts
+++ b/frontend/src/services/auth.ts
@@ -1,8 +1,13 @@
 import axios from "axios";
+import { axiosNotIntercepted } from "./axiosIntercept";
 
 export const login = (phone_number: string, password: string) => {
   return axios.post("/auth/login", {
     phone_number: phone_number,
     password: password,
   });
+};
+
+export const refreshAccessToken = () => {
+  return axiosNotIntercepted.get("/auth/token/refresh");
 };

--- a/frontend/src/services/axiosIntercept.ts
+++ b/frontend/src/services/axiosIntercept.ts
@@ -1,0 +1,49 @@
+import axios from "axios";
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { refreshAccessToken } from "./auth";
+
+export const axiosNotIntercepted = axios.create();
+axiosNotIntercepted.defaults.baseURL = import.meta.env.VITE_BACKEND_URL;
+axiosNotIntercepted.defaults.withCredentials = true;
+
+export const setupInterceptors = () => {
+  const navigate = useNavigate();
+  const [tokenExpired, setTokenExpired] = useState(false);
+
+  // Using a useEffect for using the navigate hook, since it can't be used outside of a component (in the interceptor)
+  useEffect(() => {
+    if (tokenExpired) {
+      navigate("/");
+      localStorage.setItem("isLoggedIn", "false");
+      setTokenExpired(false);
+    }
+  }, [tokenExpired]);
+
+  // This is an interceptor that will run every time a request fails.
+  // It will try to refresh the access token and retry the original request.
+  axios.interceptors.response.use(
+    function (response) {
+      // If the request is successful, no need to retry
+      return response;
+    },
+    function (error) {
+      return (
+        // Update the Access Token, this request is not intercepted (avoiding recursion, and return an error if it fails)
+        refreshAccessToken()
+          .then(() => {
+            // Retry the original request with the updated token
+            return axios(error.config);
+          })
+          .catch((refreshError) => {
+            // Handle token refresh error, and return the original error
+            if (refreshError.response.status === 401) {
+              setTokenExpired(true);
+            }
+
+            return Promise.reject(refreshError);
+          })
+      );
+    }
+  );
+};

--- a/frontend/src/utils/ProtectedRouter/protectedRoutes.tsx
+++ b/frontend/src/utils/ProtectedRouter/protectedRoutes.tsx
@@ -1,5 +1,4 @@
 import { Outlet, Navigate } from "react-router-dom";
-import Cookies from "js-cookie";
 
 export const ProtectRoutes = () => {
   return localStorage.getItem("isLoggedIn") == "true" ? (


### PR DESCRIPTION
Moved refresh token to a separate path to avoid sending it on every request.
Created an interceptor for refreshing token if a request fails.