### PR TITLE
feat: WS ping interval automatically stop and start

### DIFF
--- a/backend/controllers/assembly.ts
+++ b/backend/controllers/assembly.ts
@@ -4,7 +4,6 @@ import { User } from "../models/user";
 import { Votation, Option } from "../models/vote";
 import { RequestWithNtnuiNo } from "../utils/request";
 import { AssemblyResponseType } from "../types/assembly";
-import { organizerConnections } from "../utils/socketNotifier";
 
 export async function createAssembly(req: RequestWithNtnuiNo, res: Response) {
   if (!req.ntnuiNo) {
@@ -112,8 +111,7 @@ export async function deleteAssembly(req: RequestWithNtnuiNo, res: Response) {
       });
 
       await Assembly.deleteOne({ _id: assembly._id });
-      // Clean up websocket connections for this assembly
-      organizerConnections.delete(group);
+
       return res.status(200).json({ message: "Assembly successfully deleted" });
     }
   }

--- a/backend/index.ts
+++ b/backend/index.ts
@@ -64,12 +64,6 @@ server.on("upgrade", function upgrade(request, socket, head) {
   }
 });
 
-// Start sending pings/Heartbeat to ws-connections to keep connections alive.
-// Not started when testing, as Jest will not stop properly if the interval is running.
-if (process.env.NODE_ENV !== "test") {
-  startHeartbeatInterval();
-}
-
 try {
   // Jest will start app itself when testing, and not run on port 3000 to avoid collisions.
   if (process.env.NODE_ENV !== "test") {

--- a/backend/index.ts
+++ b/backend/index.ts
@@ -67,7 +67,7 @@ server.on("upgrade", function upgrade(request, socket, head) {
 // Start sending pings/Heartbeat to ws-connections to keep connections alive.
 // Not started when testing, as Jest will not stop properly if the interval is running.
 if (process.env.NODE_ENV !== "test") {
-  startHeartbeatInterval;
+  startHeartbeatInterval();
 }
 
 try {

--- a/backend/index.ts
+++ b/backend/index.ts
@@ -13,7 +13,6 @@ import votationRoutes from "./routes/votation";
 import { parse } from "url";
 import { lobbyWss } from "./wsServers/lobby";
 import { organizerWss } from "./wsServers/organizer";
-import { startHeartbeatInterval } from "./utils/socketNotifier";
 
 dotenv.config();
 

--- a/backend/utils/socketNotifier.ts
+++ b/backend/utils/socketNotifier.ts
@@ -13,12 +13,12 @@ import { NTNUINoFromRequest } from "./wsCookieRetriever";
 // Store all active organizer connections, the connections are stored by their respective groupSlug.
 // This makes it possible to send messages to all logged in organizers of a group.
 // An organizer can be logged in on multiple devices, and multiple organizers can receive events from the same group.
-export const organizerConnections = new Map<string, WebSocket[]>();
+const organizerConnections = new Map<string, WebSocket[]>();
 // Store all active lobby connections, for access when sending messages to assembly participants.
 // Maximum one lobby connection per user.
-export const lobbyConnections = new Map<number, WebSocket>();
+const lobbyConnections = new Map<number, WebSocket>();
 
-export let heartBeatInterval: NodeJS.Timeout | undefined;
+let heartBeatInterval: NodeJS.Timeout | undefined;
 
 const sendPing = (ws: WebSocket) => {
   if (ws.readyState === WebSocket.OPEN) {
@@ -27,7 +27,7 @@ const sendPing = (ws: WebSocket) => {
 };
 
 // Send ping to all participants to check if they are still connected and prevent the connection from closing.
-export const startHeartbeatInterval = () => {
+const startHeartbeatInterval = () => {
   heartBeatInterval = setInterval(() => {
     lobbyConnections.forEach((ws: WebSocket, userID: number) => {
       // Remove connection if it is closed by the client.
@@ -80,13 +80,6 @@ export const storeLobbyConnectionByCookie = (
     if (!heartBeatInterval) {
       startHeartbeatInterval();
     }
-  }
-};
-
-export const removeLobbyConnectionByCookie = (req: IncomingMessage) => {
-  const ntnuiNo = NTNUINoFromRequest(req);
-  if (ntnuiNo !== null) {
-    lobbyConnections.delete(ntnuiNo);
   }
 };
 

--- a/backend/utils/socketNotifier.ts
+++ b/backend/utils/socketNotifier.ts
@@ -25,27 +25,29 @@ const sendPing = (ws: WebSocket) => {
 };
 
 // Send ping to all participants to check if they are still connected and prevent the connection from closing.
-export const startHeartbeatInterval = setInterval(() => {
-  lobbyConnections.forEach((ws: WebSocket, userID: number) => {
-    // Remove connection if it is closed by the client.
-    if (ws.readyState === WebSocket.CLOSED) {
-      lobbyConnections.delete(userID);
-      return;
-    }
-    sendPing(ws);
-  });
-
-  organizerConnections.forEach((socketList) => {
-    socketList.forEach((ws: WebSocket) => {
+export const startHeartbeatInterval = () => {
+  return setInterval(() => {
+    lobbyConnections.forEach((ws: WebSocket, userID: number) => {
       // Remove connection if it is closed by the client.
       if (ws.readyState === WebSocket.CLOSED) {
-        socketList.splice(socketList.indexOf(ws), 1);
+        lobbyConnections.delete(userID);
         return;
       }
       sendPing(ws);
     });
-  });
-}, 30000); // 30 seconds
+
+    organizerConnections.forEach((socketList) => {
+      socketList.forEach((ws: WebSocket) => {
+        // Remove connection if it is closed by the client.
+        if (ws.readyState === WebSocket.CLOSED) {
+          socketList.splice(socketList.indexOf(ws), 1);
+          return;
+        }
+        sendPing(ws);
+      });
+    });
+  }, 30000); // 30 seconds
+};
 
 export const storeLobbyConnectionByCookie = (
   ws: WebSocket,

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,11 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="src/assets/ntnui.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <script defer data-domain="vote.ntnui.no" src="https://analytics.ntnui.no/js/script.js"></script>
+    <script
+      defer
+      data-domain="vote.ntnui.no"
+      src="https://analytics.ntnui.no/js/script.js"
+    ></script>
     <title>NTNUI Vote</title>
   </head>
   <body>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="src/assets/ntnui.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <script defer data-domain="vote.ntnui.no" src="https://analytics.ntnui.no/js/script.js"></script>
     <title>NTNUI Vote</title>
   </head>
   <body>


### PR DESCRIPTION
Return setInterval as a function. This way we can restrict it from running when testing.

Also make ping interval stop when there is no connections left, and start when a new WS client connects. This prevent the interval from running forever.