### PR TITLE
feat: log overview

### DIFF
--- a/backend/controllers/assembly.ts
+++ b/backend/controllers/assembly.ts
@@ -4,6 +4,7 @@ import { Votation, Option } from "../models/vote";
 import { RequestWithNtnuiNo } from "../utils/request";
 import { AssemblyResponseType } from "../types/assembly";
 import { Organizer } from "../models/organizer";
+import { Log } from "../models/log";
 
 export async function createAssembly(req: RequestWithNtnuiNo, res: Response) {
   const group = req.body.groupSlug;
@@ -75,6 +76,8 @@ export async function deleteAssembly(req: RequestWithNtnuiNo, res: Response) {
   await Organizer.deleteMany({ assembly_id: assembly._id });
 
   await Assembly.deleteOne({ _id: assembly._id });
+
+  await Log.deleteMany({ assembly_id: assembly._id });
 
   return res.status(200).json({ message: "Assembly successfully deleted" });
 }

--- a/backend/controllers/log.ts
+++ b/backend/controllers/log.ts
@@ -1,0 +1,21 @@
+import { Log } from "../models/log";
+import { RequestWithNtnuiNo } from "../utils/request";
+import { Response } from "express";
+
+export const getLogsForAssembly = async (
+  req: RequestWithNtnuiNo,
+  res: Response
+): Promise<Response> => {
+  const assemblyID = req.params.groupSlug;
+
+  try {
+    const logs = await Log.find({ assemblyID: assemblyID }).sort({
+      createdAt: -1,
+    });
+    return res.status(200).json(logs);
+  } catch (error) {
+    return res
+      .status(500)
+      .json({ message: "Error while fetching logs for the assembly" });
+  }
+};

--- a/backend/index.ts
+++ b/backend/index.ts
@@ -17,6 +17,7 @@ import groupRoutes from "./routes/groups";
 import { swaggerOptions } from "./utils/swagger";
 import swaggerJsdoc from "swagger-jsdoc";
 import swaggerUi from "swagger-ui-express";
+import logRoutes from "./routes/log";
 
 dotenv.config();
 
@@ -51,6 +52,7 @@ app.use("/assembly", assemblyRoutes);
 app.use("/qr", qrRoutes);
 app.use("/votation", votationRoutes);
 app.use("/groups", groupRoutes);
+app.use("/logs", logRoutes);
 
 app.use("/", swaggerUi.serve, swaggerUi.setup(swaggerDocs));
 

--- a/backend/routes/log.ts
+++ b/backend/routes/log.ts
@@ -1,0 +1,30 @@
+import { Router } from "express";
+import { getLogsForAssembly } from "../controllers/log";
+import authorization from "../utils/authorizationMiddleware";
+import { isOrganizer } from "../utils/permissionMiddleware";
+
+const logRoutes = Router();
+
+/**
+ * @openapi
+ * /logs/{groupSlug}:
+ *   get:
+ *     summary: Fetch logs for a specific assembly
+ *     tags:
+ *       - Logs
+ *     parameters:
+ *       - in: path
+ *         name: groupSlug
+ *         required: true
+ *         description: The slug of the assembly to fetch logs for
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Successfully retrieved logs
+ *       500:
+ *         description: Internal server error while fetching logs
+ */
+logRoutes.get("/:groupSlug", authorization, isOrganizer, getLogsForAssembly);
+
+export default logRoutes;

--- a/backend/utils/permissionMiddleware.ts
+++ b/backend/utils/permissionMiddleware.ts
@@ -8,10 +8,18 @@ export async function isOrganizer(
   res: Response,
   next: NextFunction
 ) {
+  /**
+   * This is a middleware function that checks if the user is an organizer of a given group.
+   * If the user is an organizer, the function calls the next function for the route.
+   * If the user is not an organizer, the function returns a 403 Forbidden response.
+   *
+   * The request must contain the groupSlug either in the body or in the parameters.
+   * If the user is an organizer for the given group, the user gets access.
+   */
   if (!req.ntnuiNo) {
     return res.status(401).json({ message: "Unauthorized" });
   }
-  const groupSlug = req.body.groupSlug;
+  const groupSlug = req.body.groupSlug || req.params.groupSlug;
   const user = await User.findById(req.ntnuiNo);
 
   if (user) {

--- a/frontend/src/components/AssemblyLogs.tsx
+++ b/frontend/src/components/AssemblyLogs.tsx
@@ -1,0 +1,101 @@
+import { useEffect, useState } from "react";
+import {
+  Button,
+  Modal,
+  Text,
+  Title,
+  Card,
+  Divider,
+  CopyButton,
+} from "@mantine/core";
+import { fetchAssemblyLogs } from "../services/log";
+import { LogType } from "../types/log";
+import { Clipboard } from "tabler-icons-react";
+
+export function AssemblyLogModal(state: { groupSlug: string }) {
+  const [openAddOrganizerModal, setOpenAddOrganizerModal] = useState(false);
+  const [logs, setLogs] = useState<LogType[]>([]);
+
+  const fetchLogs = async () => {
+    const logs = await fetchAssemblyLogs(state.groupSlug);
+    setLogs(logs);
+  };
+
+  useEffect(() => {
+    fetchLogs();
+  }, []);
+
+  return (
+    <Button onClick={() => setOpenAddOrganizerModal(true)} m={10}>
+      <Modal
+        opened={openAddOrganizerModal}
+        onClose={() => setOpenAddOrganizerModal(false)}
+        size="lg"
+        centered
+        transition="fade"
+        transitionDuration={200}
+        exitTransitionDuration={200}
+        // Styling is done like this to overwrite Mantine styling, therefore global color variables is not used.
+        styles={{
+          modal: {
+            backgroundColor: "#1b202c",
+            color: "white",
+            border: ".5px solid",
+            borderRadius: 5,
+            borderBottomRightRadius: 0,
+            borderColor: "#f8f082",
+          },
+          title: {
+            margin: "0 auto",
+          },
+        }}
+      >
+        <Title mb={10}>Check-in/out logs</Title>
+        <CopyButton
+          value={logs
+            .map(
+              (log) =>
+                log.user.first_name +
+                " " +
+                log.user.last_name +
+                " - " +
+                log.action +
+                " at " +
+                new Date(log.createdAt).toLocaleTimeString()
+            )
+            .join("\n")}
+        >
+          {({ copied, copy }) => (
+            <Button
+              mb={10}
+              color={copied ? "teal" : "blue"}
+              onClick={copy}
+              leftIcon={<Clipboard />}
+            >
+              Copy logs
+            </Button>
+          )}
+        </CopyButton>
+        <Card
+          shadow="xs"
+          radius="md"
+          mah={400}
+          mih={200}
+          color="dark"
+          sx={{ overflowY: "scroll" }}
+        >
+          {logs.map((log) => (
+            <>
+              <Text p={10} key={log._id}>
+                {log.user.first_name} {log.user.last_name} - {log.action} at{" "}
+                {new Date(log.createdAt).toLocaleTimeString()}
+              </Text>
+              <Divider />
+            </>
+          ))}
+        </Card>
+      </Modal>
+      Logs
+    </Button>
+  );
+}

--- a/frontend/src/components/AssemblyLogs.tsx
+++ b/frontend/src/components/AssemblyLogs.tsx
@@ -7,26 +7,31 @@ import {
   Card,
   Divider,
   CopyButton,
+  Flex,
+  Loader,
+  Box,
 } from "@mantine/core";
 import { fetchAssemblyLogs } from "../services/log";
 import { LogType } from "../types/log";
-import { Clipboard } from "tabler-icons-react";
+import { Clipboard, Container } from "tabler-icons-react";
 
 export function AssemblyLogModal(state: { groupSlug: string }) {
   const [openAddOrganizerModal, setOpenAddOrganizerModal] = useState(false);
-  const [logs, setLogs] = useState<LogType[]>([]);
+  const [logs, setLogs] = useState<LogType[]>();
 
   const fetchLogs = async () => {
     const logs = await fetchAssemblyLogs(state.groupSlug);
     setLogs(logs);
   };
 
-  useEffect(() => {
-    fetchLogs();
-  }, []);
-
   return (
-    <Button onClick={() => setOpenAddOrganizerModal(true)} m={10}>
+    <Button
+      onClick={() => {
+        setOpenAddOrganizerModal(true);
+        fetchLogs();
+      }}
+      m={10}
+    >
       <Modal
         opened={openAddOrganizerModal}
         onClose={() => setOpenAddOrganizerModal(false)}
@@ -50,50 +55,63 @@ export function AssemblyLogModal(state: { groupSlug: string }) {
           },
         }}
       >
-        <Title mb={10}>Check-in/out logs</Title>
-        <CopyButton
-          value={logs
-            .map(
-              (log) =>
-                log.user.first_name +
-                " " +
-                log.user.last_name +
-                " - " +
-                log.action +
-                " at " +
-                new Date(log.createdAt).toLocaleTimeString()
-            )
-            .join("\n")}
-        >
-          {({ copied, copy }) => (
-            <Button
-              mb={10}
-              color={copied ? "teal" : "blue"}
-              onClick={copy}
-              leftIcon={<Clipboard />}
+        {!logs ? (
+          <Loader />
+        ) : (
+          <>
+            <Flex
+              direction="row"
+              align="center"
+              justify={"space-between"}
+              gap={10}
             >
-              Copy logs
-            </Button>
-          )}
-        </CopyButton>
-        <Card
-          shadow="xs"
-          radius="md"
-          mah={400}
-          mih={200}
-          color="dark"
-          sx={{ overflowY: "scroll" }}
-        >
-          {logs.map((log) => (
-            <>
-              <Text p={10} key={log._id}>
-                {log.user.first_name} {log.user.last_name} - {log.action} at{" "}
-                {new Date(log.createdAt).toLocaleTimeString()}
-              </Text>
-              <Divider />
-            </>
-          ))}
-        </Card>
+              <Title mb={10}>Check-in/out logs</Title>
+              <CopyButton
+                value={logs
+                  .map(
+                    (log) =>
+                      log.user.first_name +
+                      " " +
+                      log.user.last_name +
+                      " - " +
+                      log.action +
+                      " at " +
+                      new Date(log.createdAt).toLocaleTimeString()
+                  )
+                  .join("\n")}
+              >
+                {({ copied, copy }) => (
+                  <Button
+                    mb={10}
+                    color={copied ? "teal" : "blue"}
+                    onClick={copy}
+                    leftIcon={<Clipboard />}
+                  >
+                    Copy logs
+                  </Button>
+                )}
+              </CopyButton>
+            </Flex>
+            <Card
+              shadow="xs"
+              radius="md"
+              mah={400}
+              mih={200}
+              color="dark"
+              sx={{ overflowY: "scroll" }}
+            >
+              {logs.map((log) => (
+                <Box key={log._id}>
+                  <Text p={10}>
+                    {log.user.first_name} {log.user.last_name} - {log.action} at{" "}
+                    {new Date(log.createdAt).toLocaleTimeString()}
+                  </Text>
+                  <Divider />
+                </Box>
+              ))}
+            </Card>
+          </>
+        )}
       </Modal>
       Logs
     </Button>

--- a/frontend/src/components/EditAssembly.tsx
+++ b/frontend/src/components/EditAssembly.tsx
@@ -315,75 +315,85 @@ export function EditAssembly(state: { group: UserDataGroupType }) {
           </Container>
         </Container>
         <Container p={0} pt={"xs"} w={breakpoint ? "45%" : "95%"}>
-          <Container
-            sx={{
-              display: "flex",
-              justifyContent: "flex-end",
-              alignItems: "center",
-            }}
-          >
-            <Button
-              mb={10}
-              mr={-15}
-              onClick={() => addCase()}
-              data-testid="add-case-button"
-            >
-              Add votation
-            </Button>
-          </Container>
-
           {votations.length < 1 ? (
-            <Text data-testid="no-cases-warning">
-              There are currently no votations in this assembly.
-            </Text>
+            <>
+              <Text data-testid="no-cases-warning">
+                There are currently no votations in this assembly.
+              </Text>
+              <Button
+                m={10}
+                onClick={() => addCase()}
+                data-testid="add-case-button"
+              >
+                Add votation
+              </Button>
+            </>
           ) : (
-            <Accordion
-              sx={(theme) => ({
-                height: "fit-content",
-                backgroundColor: theme.colors.ntnui_background[0],
-                border: "solid",
-                borderColor: theme.colors.ntnui_yellow[0],
-                borderRadius: "5px",
-                borderBottomRightRadius: "0px",
-                borderBottomWidth: 0.5,
-                maxWidth: 780,
-              })}
-              multiple
-              value={accordionActiveTabs}
-              onChange={setAccordionActiveTabs}
-            >
-              {votations
-                .sort((a, b) => a.caseNumber - b.caseNumber)
-                .map((vote: VoteType) => {
-                  return vote.isFinished ? (
-                    <Results
-                      key={vote._id}
-                      votation={vote}
-                      addCase={(votationTemplate: VoteType) =>
-                        addCase(votationTemplate)
-                      }
-                    />
-                  ) : (
-                    <VotationPanel
-                      // Passing accordionActiveTabs to VotationPanel so it can provide it's ID to remain open when vote is submitted.
-                      accordionActiveTabs={accordionActiveTabs}
-                      setAccordionActiveTabs={(tabs: string[]) =>
-                        setAccordionActiveTabs(tabs)
-                      }
-                      key={vote._id}
-                      votation={vote}
-                      groupSlug={group.groupSlug}
-                      isChanged={isChanged}
-                      setIsChanged={setIsChanged}
-                      assemblyStatus={assembly.isActive}
-                      initEditable={vote.editable || false}
-                      addCase={(votationTemplate: VoteType) =>
-                        addCase(votationTemplate)
-                      }
-                    />
-                  );
+            <>
+              <Container
+                sx={{
+                  display: "flex",
+                  justifyContent: "flex-end",
+                  alignItems: "center",
+                }}
+              >
+                <Button
+                  mb={10}
+                  mr={-15}
+                  onClick={() => addCase()}
+                  data-testid="add-case-button"
+                >
+                  Add votation
+                </Button>
+              </Container>
+              <Accordion
+                sx={(theme) => ({
+                  height: "fit-content",
+                  backgroundColor: theme.colors.ntnui_background[0],
+                  border: "solid",
+                  borderColor: theme.colors.ntnui_yellow[0],
+                  borderRadius: "5px",
+                  borderBottomRightRadius: "0px",
+                  borderBottomWidth: 0.5,
+                  maxWidth: 780,
                 })}
-            </Accordion>
+                multiple
+                value={accordionActiveTabs}
+                onChange={setAccordionActiveTabs}
+              >
+                {votations
+                  .sort((a, b) => a.caseNumber - b.caseNumber)
+                  .map((vote: VoteType) => {
+                    return vote.isFinished ? (
+                      <Results
+                        key={vote._id}
+                        votation={vote}
+                        addCase={(votationTemplate: VoteType) =>
+                          addCase(votationTemplate)
+                        }
+                      />
+                    ) : (
+                      <VotationPanel
+                        // Passing accordionActiveTabs to VotationPanel so it can provide it's ID to remain open when vote is submitted.
+                        accordionActiveTabs={accordionActiveTabs}
+                        setAccordionActiveTabs={(tabs: string[]) =>
+                          setAccordionActiveTabs(tabs)
+                        }
+                        key={vote._id}
+                        votation={vote}
+                        groupSlug={group.groupSlug}
+                        isChanged={isChanged}
+                        setIsChanged={setIsChanged}
+                        assemblyStatus={assembly.isActive}
+                        initEditable={vote.editable || false}
+                        addCase={(votationTemplate: VoteType) =>
+                          addCase(votationTemplate)
+                        }
+                      />
+                    );
+                  })}
+              </Accordion>
+            </>
           )}
         </Container>
       </Flex>

--- a/frontend/src/components/EditAssembly.tsx
+++ b/frontend/src/components/EditAssembly.tsx
@@ -27,6 +27,7 @@ import { useMediaQuery } from "@mantine/hooks";
 import useWebSocket from "react-use-websocket";
 import { showNotification } from "@mantine/notifications";
 import { AddOrganizerButtonModal } from "./AddOrganizer";
+import { AssemblyLogModal } from "./AssemblyLogs";
 
 export function EditAssembly(state: { group: UserDataGroupType }) {
   const breakpoint = useMediaQuery("(min-width: 1010px)");
@@ -218,13 +219,7 @@ export function EditAssembly(state: { group: UserDataGroupType }) {
             <Text>Logged in participants: {participants}</Text>
             <Text>Submitted votes on current votation: {submittedVotes}</Text>
 
-            <Flex
-              justify={"center"}
-              wrap="wrap"
-              rowGap={"0.5rem"}
-              columnGap={"0.5rem"}
-              maw={450}
-            >
+            <Flex justify={"center"} wrap="wrap" rowGap={"0.5rem"} maw={450}>
               {assembly.isActive ? (
                 <Button
                   color={"red"}
@@ -284,11 +279,11 @@ export function EditAssembly(state: { group: UserDataGroupType }) {
                     </Text>
                     <Text ta={"center"}>All data will be lost!</Text>
                     <Container
-                      sx={(theme) => ({
+                      sx={{
                         display: "flex",
                         flexDirection: "row",
                         justifyContent: "space-evenly",
-                      })}
+                      }}
                     >
                       <Button
                         data-testid="delete-button"
@@ -315,18 +310,28 @@ export function EditAssembly(state: { group: UserDataGroupType }) {
               {!assembly.isExtraOrganizer && (
                 <AddOrganizerButtonModal groupSlug={group.groupSlug} />
               )}
-
-              <Button
-                onClick={() => addCase()}
-                m={10}
-                data-testid="add-case-button"
-              >
-                Add votation
-              </Button>
+              <AssemblyLogModal groupSlug={group.groupSlug} />
             </Flex>
           </Container>
         </Container>
         <Container p={0} pt={"xs"} w={breakpoint ? "45%" : "95%"}>
+          <Container
+            sx={{
+              display: "flex",
+              justifyContent: "flex-end",
+              alignItems: "center",
+            }}
+          >
+            <Button
+              mb={10}
+              mr={-15}
+              onClick={() => addCase()}
+              data-testid="add-case-button"
+            >
+              Add votation
+            </Button>
+          </Container>
+
           {votations.length < 1 ? (
             <Text data-testid="no-cases-warning">
               There are currently no votations in this assembly.

--- a/frontend/src/components/VotationPanel.tsx
+++ b/frontend/src/components/VotationPanel.tsx
@@ -284,7 +284,7 @@ function VotationPanel({
             />
 
             <Button type="submit" mt={10} data-testid="submitButton">
-              Save current vote
+              Save
             </Button>
           </form>
         </Accordion.Panel>

--- a/frontend/src/services/log.ts
+++ b/frontend/src/services/log.ts
@@ -1,0 +1,14 @@
+import axios from "axios";
+import { LogType } from "../types/log";
+
+export const fetchAssemblyLogs = async (
+  groupSlug: string
+): Promise<LogType[]> => {
+  try {
+    const response = await axios.get(`/logs/${groupSlug}`);
+    return response.data;
+  } catch (error) {
+    console.error("Error fetching logs:", error);
+    throw new Error("Failed to fetch logs");
+  }
+};

--- a/frontend/src/types/log.ts
+++ b/frontend/src/types/log.ts
@@ -1,0 +1,10 @@
+import { UserType } from "./user";
+
+export type LogType = {
+  _id: string;
+  assemblyID: string;
+  action: string;
+  user: UserType;
+  createdAt: string;
+  __v: number;
+};


### PR DESCRIPTION
The check-in/out logs for a given assembly is never presented in the frontend.
In this PR a modal is added to the organizer page for displaying the logs for a given assembly.
The logs are also deleted together with the assembly.


![Skjermbilde 2024-12-31 kl  14 52 37](https://github.com/user-attachments/assets/e7854815-3a58-4be9-90a6-7e176ac5810a)

